### PR TITLE
feat(dashboard): Add dynamic dashboard with preview and configuration

### DIFF
--- a/lua/sticky_pad/config.lua
+++ b/lua/sticky_pad/config.lua
@@ -1,0 +1,50 @@
+---@class Config
+---@field sticker_width integer
+---@field sticker_height integer
+---@field col integer
+---@field row integer
+---@field padding integer
+---@field position string
+
+local Config = {}
+Config.__index = Config
+
+local default_width = math.floor(vim.o.columns * 0.15)
+local config = {
+  sticker_width = default_width,
+  sticker_height = math.floor(default_width / 2),
+  position = "",
+  col = 0,
+  row = 0,
+  padding = 2
+}
+
+local cases = {
+  ["top-left"] = function() return { 1, 1 } end,
+  ["bottom-left"] = function() return { vim.o.lines - config.sticker_height - config.padding, 1 } end,
+  ["bottom-right"] = function()
+    return { vim.o.lines - config.sticker_height - config.padding, vim.o.columns - config.sticker_width - config.padding }
+  end,
+  default = function() return { 1, vim.o.columns - config.sticker_width - config.padding } end,
+}
+
+
+function Config.set(opts)
+  for k, v in pairs(opts) do
+    if not config[k] then
+      print("Unknown option for configuraiton of pluguin: ", k)
+      goto continue
+    end
+    config[k] = v
+    ::continue::
+  end
+  local cords = cases[config.position] or cases.default()
+  config.row = cords[1]
+  config.col = cords[2]
+end
+
+function Config.get()
+  return config
+end
+
+return Config

--- a/lua/sticky_pad/init.lua
+++ b/lua/sticky_pad/init.lua
@@ -2,6 +2,7 @@ local M = {}
 local dashboard = require("sticky_pad.dashboard")
 local stickers = require("sticky_pad.sticker")
 local list = require("sticky_pad.list")
+local config = require("sticky_pad.config")
 list.new()
 
 local function open_dashboard()
@@ -12,8 +13,7 @@ local function open_dashboard()
   my_dashboard:show()
 end
 
-local function setup_user_commands(opts)
-  local targe_file = opts.targe_file or "todo.md"
+local function setup_user_commands()
   vim.api.nvim_create_user_command("NS", function()
     stickers.create()
   end, {})
@@ -35,7 +35,6 @@ local function setup_user_commands(opts)
   vim.api.nvim_create_user_command("Fold", function()
     stickers.fold()
   end, {})
-  return targe_file
 end
 
 
@@ -49,7 +48,8 @@ local function setup_autocmd()
 end
 
 function M.setup(opts)
-  setup_user_commands(opts)
+  config.set(opts)
+  setup_user_commands()
   setup_autocmd()
   if list.get_last_used() then
     stickers.show(list.get_last_used().file_name)

--- a/lua/sticky_pad/sticker.lua
+++ b/lua/sticky_pad/sticker.lua
@@ -2,6 +2,7 @@ local M = {}
 
 local core = require("sticky_pad.core")
 local list = require("sticky_pad.list")
+local config = require("sticky_pad.config").get()
 
 -- This is the private, internal state for the one active sticker.
 local active_sticker = {
@@ -13,31 +14,32 @@ local active_sticker = {
 
 -- Helper function to get the configuration for the "full note" editing window.
 local function get_full_note_conf()
-  local width = 35
+  local width = config.width
   local height = math.floor(vim.o.lines * 0.8)
   return {
     relative = "editor",
     width = width,
     height = height,
-    col = vim.o.columns - width - 5,
-    row = 5,
-    border = "single",
+    col = config.col,
+    row = config.row,
+    border = "rounded",
     focusable = true,
+    title = "sticky.pad"
   }
 end
 
 -- Helper function to get the configuration for the small "sticker" view.
 local function get_sticker_win_conf()
-  local col = vim.o.columns - 40
   return {
-    width = 35,
-    height = 15,
-    row = 1,
-    col = col,
+    width = config.sticker_width,
+    height = config.sticker_height,
+    row = config.row,
+    col = config.col,
     relative = "editor",
-    border = "single",
+    border = "rounded",
     style = "minimal",
     focusable = false,
+    title = "sticky.pad"
   }
 end
 


### PR DESCRIPTION
This commit introduces the primary user interface for the plugin: an interactive dashboard to manage stickers.

- **Dynamic Layout:** Creates a responsive, multi-pane UI with a results list and a file preview. Window sizes are calculated dynamically based on editor dimensions.

- **Interactivity:**
    - A live preview automatically updates as the cursor moves in the results list (`CursorMoved` autocmd).
    - Keymaps are bound for closing (`q`), deleting (`dd`), and selecting (`<Enter>`) stickers.

- **Configuration Foundation:**
    - Adds the initial `config.lua` module to handle settings.
    - Lays the groundwork for making layout, keys, and appearance user-configurable.